### PR TITLE
feat(farms-prices): Add price helper LPs to get prices for farms which don't have standard quoteTokens

### DIFF
--- a/src/config/constants/priceHelperLps.ts
+++ b/src/config/constants/priceHelperLps.ts
@@ -1,0 +1,20 @@
+import tokens from './tokens'
+import { FarmConfig } from './types'
+
+const priceHelperLps: FarmConfig[] = [
+  /**
+   * These LPs are just used to help with price calculation for MasterChef LPs.
+   */
+  {
+    pid: null,
+    lpSymbol: 'QSD-BNB LP',
+    lpAddresses: {
+      97: '',
+      56: '0x7b3ae32eE8C532016f3E31C8941D937c59e055B9',
+    },
+    token: tokens.qsd,
+    quoteToken: tokens.wbnb,
+  },
+]
+
+export default priceHelperLps

--- a/src/state/farms/fetchFarms.ts
+++ b/src/state/farms/fetchFarms.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import erc20 from 'config/abi/erc20.json'
 import masterchefABI from 'config/abi/masterchef.json'
 import multicall from 'utils/multicall'
-import { BIG_TEN } from 'utils/bigNumber'
+import { BIG_TEN, BIG_ZERO } from 'utils/bigNumber'
 import { getAddress, getMasterChefAddress } from 'utils/addressHelpers'
 import { FarmConfig } from 'config/constants/types'
 
@@ -63,19 +63,21 @@ const fetchFarms = async (farmsToFetch: FarmConfig[]) => {
       // Total staked in LP, in quote token value
       const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
 
-      const [info, totalAllocPoint] = await multicall(masterchefABI, [
-        {
-          address: getMasterChefAddress(),
-          name: 'poolInfo',
-          params: [farmConfig.pid],
-        },
-        {
-          address: getMasterChefAddress(),
-          name: 'totalAllocPoint',
-        },
-      ])
+      const [info, totalAllocPoint] = farmConfig.pid
+        ? await multicall(masterchefABI, [
+            {
+              address: getMasterChefAddress(),
+              name: 'poolInfo',
+              params: [farmConfig.pid],
+            },
+            {
+              address: getMasterChefAddress(),
+              name: 'totalAllocPoint',
+            },
+          ])
+        : [BIG_ZERO, BIG_ZERO]
 
-      const allocPoint = new BigNumber(info.allocPoint._hex)
+      const allocPoint = new BigNumber(info?.allocPoint?._hex)
       const poolWeight = allocPoint.div(new BigNumber(totalAllocPoint))
 
       return {

--- a/src/state/farms/fetchFarmsPrices.ts
+++ b/src/state/farms/fetchFarmsPrices.ts
@@ -87,7 +87,7 @@ const fetchFarmsPrices = async (farms) => {
 
   // Filter out price helper LP config farms
   const farmsWithoutHelperLps = farmsWithPrices.filter((farm: Farm) => {
-    return Boolean(farm.pid || farm.pid === 0)
+    return farm.pid || farm.pid === 0
   })
 
   return farmsWithoutHelperLps

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit'
 import farmsConfig from 'config/constants/farms'
+import priceHelperLpsConfig from 'config/constants/priceHelperLps'
 import isArchivedPid from 'utils/farmHelpers'
 import fetchFarms from './fetchFarms'
 import fetchFarmsPrices from './fetchFarmsPrices'
@@ -58,12 +59,12 @@ export const { setFarmsPublicData, setFarmUserData, setLoadArchivedFarmsData } =
 
 // Thunks
 export const fetchFarmsPublicDataAsync = () => async (dispatch, getState) => {
-  const state = getState()
-  const apiPriceData = state.apiPrices.data
-  const fetchArchived = state.farms.loadArchivedFarmsData
+  const fetchArchived = getState().farms.loadArchivedFarmsData
   const farmsToFetch = fetchArchived ? farmsConfig : nonArchivedFarms
   const farms = await fetchFarms(farmsToFetch)
-  const farmsWithPrices = await fetchFarmsPrices(farms, apiPriceData)
+  const priceHelperLps = await fetchFarms(priceHelperLpsConfig)
+  const farmsForPriceCalc = farms.concat(priceHelperLps)
+  const farmsWithPrices = await fetchFarmsPrices(farmsForPriceCalc)
   dispatch(setFarmsPublicData(farmsWithPrices))
 }
 export const fetchFarmUserDataAsync = (account: string) => async (dispatch, getState) => {


### PR DESCRIPTION
Example PR to show how a second farms config, used to assist with price calculation, _could_ be used.

1. Add `priceHelperLps.ts` config
2. Pass these to `fetchFarms` to get data necessary for price calculation for those LPs.
3. Concat the unofficial farms with the MC farms and pass them into the `fetchFarmsPrices` function
4. After `fetchFarmsPrices` has populated farms with prices, filter out any farms without pids (the unofficial LPs) and return them prior to storing in state.

Pros
- Faster and unified fetching of all prices used in the FE
- We can remove the API call

Cons
- Manual burden to add LP price helper pools when a farm with an irregular quoteToken is being added
- Additional conditional logic for farms without pids