### PR TITLE
Ultimate curves solution

### DIFF
--- a/src/components/PageSection/CurvedDivider.tsx
+++ b/src/components/PageSection/CurvedDivider.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { CurvedSvgTop, CurvedSvgBottom, ConcaveTop } from './svg/CurvedSvg'
+import { CurvedSvgTop, CurvedSvgBottom, ConcaveTop, ConcaveBottom } from './svg/CurvedSvg'
 
 interface CurvedDividerProps extends WrapperProps {
   svgFill?: string
@@ -32,10 +32,12 @@ const CurvedDivider: React.FC<CurvedDividerProps> = ({ svgFill, index, curvePosi
   const showTopDivider = curvePosition === 'top' && !concave
   const showBottomDivider = curvePosition === 'bottom' && !concave
   const showConcaveTopDivider = curvePosition === 'top' && concave
+  const showConcaveBottomDivider = curvePosition === 'bottom' && concave
   return (
     <Wrapper index={index}>
       {dividerComponent && <ComponentWrapper index={index}>{dividerComponent}</ComponentWrapper>}
       {showConcaveTopDivider && <ConcaveTop />}
+      {showConcaveBottomDivider && <ConcaveBottom />}
       {showTopDivider && <CurvedSvgTop svgFill={svgFill} width="100%" />}
       {showBottomDivider && <CurvedSvgBottom svgFill={svgFill} width="100%" />}
     </Wrapper>

--- a/src/components/PageSection/index.tsx
+++ b/src/components/PageSection/index.tsx
@@ -90,6 +90,7 @@ const PageSection: React.FC<PageSectionProps> = ({
         <CurvedDivider
           svgFill={svgFill}
           index={index}
+          concave={concaveDivider}
           curvePosition={curvePosition}
           dividerComponent={dividerComponent}
         />

--- a/src/components/PageSection/svg/CurvedSvg.tsx
+++ b/src/components/PageSection/svg/CurvedSvg.tsx
@@ -11,19 +11,6 @@ svg {
     box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
   }
 `
-// Only used on lottery page
-const LotteryConcaveTopSvg: React.FC<SvgProps> = (props) => {
-  return (
-    <Svg viewBox="0 0 1440 17" {...props}>
-      <svg width="1440" height="17" viewBox="0 0 1440 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M0 16.8146V0.814575C179.359 10.0203 435.559 15.7808 720 15.7808C1004.44 15.7808 1260.64 10.0203 1440 0.814575V16.8146H0Z"
-          fill="#7645D9"
-        />
-      </svg>
-    </Svg>
-  )
-}
 
 const CurvedSvg: React.FC<SvgProps> = (props) => {
   return (
@@ -69,19 +56,25 @@ export const CurvedSvgBottom = styled(CurvedSvg)<StyledSvgProps>`
   fill: ${({ svgFill, theme }) => svgFill || theme.colors.background};
 `
 
-// scale(1.05) is needed to prevent tiny half a pixel blank space on the edges
-const LotteryConcaveTop = styled(LotteryConcaveTopSvg)<StyledSvgProps>`
-  transform: scale(1.05);
-`
-
 const ConcaveContainer = styled(Box)`
   width: 100%;
-  position: relative;
-  overflow: hidden;
+  height: 20px;
+  background-color: #7645d9;
+  clip-path: url(#topConcaveCurve);
+
+  & svg {
+    display: block;
+  }
 `
 
 export const ConcaveTop = () => (
-  <ConcaveContainer mb="-4px">
-    <LotteryConcaveTop width="100%" />
+  <ConcaveContainer>
+    <svg width="0" height="0">
+      <defs>
+        <clipPath id="topConcaveCurve" clipPathUnits="objectBoundingBox">
+          <path d="M 0,0 L 0,1 L 1,1 L 1,0 C .75 1, .25 1, 0 0 Z" />
+        </clipPath>
+      </defs>
+    </svg>
   </ConcaveContainer>
 )

--- a/src/components/PageSection/svg/CurvedSvg.tsx
+++ b/src/components/PageSection/svg/CurvedSvg.tsx
@@ -56,11 +56,20 @@ export const CurvedSvgBottom = styled(CurvedSvg)<StyledSvgProps>`
   fill: ${({ svgFill, theme }) => svgFill || theme.colors.background};
 `
 
-const ConcaveContainer = styled(Box)`
+const ConcaveContainer = styled(Box)<{ clipPath: string }>`
   width: 100%;
   height: 20px;
-  background-color: #7645d9;
-  clip-path: url(#topConcaveCurve);
+  background-color: ${({ clipPath, theme }) => {
+    if (clipPath === '#topConcaveCurve') {
+      return '#7645d9'
+    }
+    if (theme.isDark) {
+      return '#66578D'
+    }
+    return '#9A9FD0'
+  }};
+  clip-path: ${({ clipPath }) => `url(${clipPath})`};
+  transform: ${({ clipPath }) => (clipPath === '#bottomConcaveCurve' ? 'translate(0, -20px)' : 'none')};
 
   & svg {
     display: block;
@@ -68,11 +77,23 @@ const ConcaveContainer = styled(Box)`
 `
 
 export const ConcaveTop = () => (
-  <ConcaveContainer>
+  <ConcaveContainer clipPath="#topConcaveCurve">
     <svg width="0" height="0">
       <defs>
         <clipPath id="topConcaveCurve" clipPathUnits="objectBoundingBox">
           <path d="M 0,0 L 0,1 L 1,1 L 1,0 C .75 1, .25 1, 0 0 Z" />
+        </clipPath>
+      </defs>
+    </svg>
+  </ConcaveContainer>
+)
+
+export const ConcaveBottom = () => (
+  <ConcaveContainer clipPath="#bottomConcaveCurve">
+    <svg width="0" height="0">
+      <defs>
+        <clipPath id="bottomConcaveCurve" clipPathUnits="objectBoundingBox">
+          <path d="M 0,1 L 0,0 L 1,0 L 1,1 C .75 0.1, .25 0.1, 0 1 Z" />
         </clipPath>
       </defs>
     </svg>

--- a/src/views/LotteryV2/components/HowToPlay.tsx
+++ b/src/views/LotteryV2/components/HowToPlay.tsx
@@ -245,7 +245,7 @@ const HowToPlay: React.FC = () => {
       </Flex>
       <StepContainer>
         {steps.map((step) => (
-          <StepCard step={step} />
+          <StepCard key={step.label} step={step} />
         ))}
       </StepContainer>
       <Divider />

--- a/src/views/LotteryV2/index.tsx
+++ b/src/views/LotteryV2/index.tsx
@@ -75,11 +75,7 @@ const LotteryV2 = () => {
       <PageSection background={CHECK_PRIZES_BG} hasCurvedDivider={false} index={2}>
         <CheckPrizesSection />
       </PageSection>
-      <PageSection
-        background={isDark ? FINISHED_ROUNDS_BG_DARK : FINISHED_ROUNDS_BG}
-        hasCurvedDivider={false}
-        index={2}
-      >
+      <PageSection background={isDark ? FINISHED_ROUNDS_BG_DARK : FINISHED_ROUNDS_BG} concaveDivider index={2}>
         <Flex width="100%" flexDirection="column" alignItems="center" justifyContent="center">
           <Heading mb="24px" scale="xl">
             {t('Finished Rounds')}


### PR DESCRIPTION
Fix for the curve on lottery page. Now uses CSS `clip-path` that is scaled perfectly on all screens
Also added the bottom curve that cause problems before with silly "plug svg pic in div" solution
Also added missing key prop